### PR TITLE
Add example docker-compose configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-MAINTAINER Reinhard Pointner <rednoah@filebot.net>
+LABEL maintainer="Reinhard Pointner <rednoah@filebot.net>"
 
 
 ENV FILEBOT_VERSION 4.9.2

--- a/Dockerfile.graalvm
+++ b/Dockerfile.graalvm
@@ -1,6 +1,6 @@
 FROM oracle/graalvm-ce:latest
 
-MAINTAINER Reinhard Pointner <rednoah@filebot.net>
+LABEL maintainer="Reinhard Pointner <rednoah@filebot.net>"
 
 
 ENV FILEBOT_VERSION 4.9.2

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,7 +1,7 @@
 FROM openjdk:14-alpine
 
 
-MAINTAINER Reinhard Pointner <rednoah@filebot.net>
+LABEL maintainer="Reinhard Pointner <rednoah@filebot.net>"
 
 
 ENV FILEBOT_VERSION 4.9.2

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,6 +1,6 @@
 FROM rednoah/filebot
 
-MAINTAINER Reinhard Pointner <rednoah@filebot.net>
+LABEL maintainer="Reinhard Pointner <rednoah@filebot.net>"
 
 ENV FILEBOT_NODE_VERSION 0.3.1
 ENV FILEBOT_NODE_URL https://github.com/filebot/filebot-node/releases/download/$FILEBOT_NODE_VERSION/filebot-node-$FILEBOT_NODE_VERSION-generic.tar.xz

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -1,6 +1,6 @@
 FROM rednoah/filebot
 
-MAINTAINER Reinhard Pointner <rednoah@filebot.net>
+LABEL maintainer="Reinhard Pointner <rednoah@filebot.net>"
 
 COPY filebot-watcher /usr/bin/filebot-watcher
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ The [`filebot`](https://www.filebot.net/cli.html) command-line tool.
 docker run --rm -it -v $PWD:/volume1 -v data:/data rednoah/filebot -script fn:sysinfo
 ```
 
+docker-compose.yml
+```
+version: '3.3'
+services:
+  filebot:
+    container_name: filebot
+    image: rednoah/filebot
+    restart: unless-stopped
+    volumes:
+      - ${HOME}/Filebot:/data
+      - ${HOME}/Downloads:/downloads
+      - ${HOME}/Output:/output #optional - see note about hardlinking
+```
 
 ## filebot-node
 
@@ -23,6 +36,22 @@ FileBot Node allows you to call the [amc script](https://www.filebot.net/amc.htm
 docker run --rm -it -v $PWD:/volume1 -v data:/data -p 5452:5452 rednoah/filebot:node
 ```
 
+docker-compose.yml
+```
+version: '3.3'
+services:
+  filebot-node:
+    container_name: filebot-node
+    image: rednoah/filebot:node
+    restart: unless-stopped
+    volumes:
+      - ${HOME}/Filebot:/data
+      - ${HOME}/Downloads:/downloads
+      - ${HOME}/Output:/output #optional - see note about hardlinking
+    ports:
+      - 5452:5452
+```
+
 Once the [FileBot Node Service](https://github.com/filebot/filebot-node) is running, you can access the  web interface via [http://localhost:5452/filebot/](http://localhost:5452/filebot/). You can create prepared tasks via `Execute ➔ Schedule` and then execute them remotely via `curl http://localhost:5452/task?id=${TASK_ID}`.
 
 You may secure the [FileBot Node Service](https://github.com/filebot/filebot-node) by using `HTTPS` and `BASIC` authentication:
@@ -30,6 +59,31 @@ You may secure the [FileBot Node Service](https://github.com/filebot/filebot-nod
 docker run --rm -it -v $PWD:/volume1 -v data:/data -p 5452:5452 -e FILEBOT_NODE_AUTH=BASIC -e FILEBOT_NODE_AUTH_USER=alice -e FILEBOT_NODE_AUTH_PASS=wxy87rFb -p 5453:5453 -v /etc/ssl:/etc/ssl:ro -e FILEBOT_NODE_HTTPS=YES -e FILEBOT_NODE_HTTPS_PORT=5453 -e FILEBOT_NODE_HTTPS_KEY=/etc/ssl/private/server.key -e FILEBOT_NODE_HTTPS_CRT=/etc/ssl/certs/server.crt rednoah/filebot:node
 ```
 
+docker-compose.yml
+```
+version: '3.3'
+services:
+  filebot-node:
+    container_name: filebot-node
+    image: rednoah/filebot:node
+    restart: unless-stopped
+    volumes:
+      - '/etc/ssl:/etc/ssl:ro'
+      - ${HOME}/Filebot:/data
+      - ${HOME}/Downloads:/downloads
+      - ${HOME}/Output:/output #optional - see note about hardlinking
+    ports:
+      - 5452:5452
+      - 5453:5453
+    environment:
+      - FILEBOT_NODE_AUTH=BASIC
+      - FILEBOT_NODE_AUTH_USER=alice
+      - FILEBOT_NODE_AUTH_PASS=wxy87rFb
+      - FILEBOT_NODE_HTTPS=YES
+      - FILEBOT_NODE_HTTPS_PORT=5453
+      - FILEBOT_NODE_HTTPS_KEY=/etc/ssl/private/server.key
+      - FILEBOT_NODE_HTTPS_CRT=/etc/ssl/certs/server.crt
+```
 
 ## filebot-watcher
 
@@ -40,6 +94,68 @@ docker run --rm -it -v $PWD:/volume1 -v data:/data rednoah/filebot:watcher /volu
 ```
 
 The first argument `$1` is the watch folder. The remaining arguments are [amc script](https://www.filebot.net/amc.html) options.
+
+docker-compose.yml
+```
+version: '3.3'
+services:
+  filebot:
+    container_name: filebot-watcher
+    image: rednoah/filebot:watcher
+    restart: unless-stopped
+    command: /downloads --output /output #The remaining arguments are amc script options: https://www.filebot.net/amc.html
+    volumes:
+      - ${HOME}/Filebot:/data
+      - ${HOME}/Downloads:/downloads
+      - ${HOME}/Output:/output #optional - see note about hardlinking
+```
+
+# Hardlinking
+One of the requirements for hardlinking, is that the input/output must exist on the same filesystem. However, due to the way docker internally handles volume mounts, this can cause problems.
+
+docker treats each volume mount, as a separate filesystem
+
+In order for filebot to support hardlinking, it is recomended to use a single volume mount, that contains both your input/output files/directories.
+
+With the following config, it is not possible to hardlink files located in `/downloads`, to `/output`
+```
+version: '3.3'
+services:
+  filebot:
+    container_name: filebot
+    image: rednoah/filebot
+    restart: unless-stopped
+    volumes:
+      - ${HOME}/Filebot:/config
+      - ${HOME}/Downloads:/downloads
+      - ${HOME}/Output:/output
+```
+
+In order to solve this problem, it is recomended to create a single directory, that contains both `/downloads` and `/media` - then mount that directory.
+
+`/home/user/Downloads`  
+`/home/user/Output`  
+  
+would become  
+  
+`/home/user/Media`  
+`/home/user/Media/Downloads`  
+`/home/user/Media/Output`  
+  
+Then you would mount the Media folder inside your container.
+```
+version: '3.3'
+services:
+  filebot:
+    container_name: filebot
+    image: rednoah/filebot
+    restart: unless-stopped
+    volumes:
+      - ${HOME}/Filebot:/config
+      - ${HOME}/Media:/media
+```
+
+This will then allow you to hardlink between /Downloads and /Output, from within the docker container
 
 
 # FAQ


### PR DESCRIPTION
I imagine the formatting will require additional tweaks, for now, this is a good starting point.

I chose not to modify the existing docker run statements. Though it wouldn't hurt to modify those to match the new docker-compose config

Also, I am strongly in favor of renaming the /data mount to /config. This will better match the linuxserver.io container structure, and be more clear and familiar to most users versus /data --I chose not to make this change to keep this PR isolated. We can discuss further if you are interested.